### PR TITLE
Add favorite/subscribed boolean filters to advanced search

### DIFF
--- a/src/app/AdvanceSearchForm.component.js
+++ b/src/app/AdvanceSearchForm.component.js
@@ -23,8 +23,8 @@ export default class AdvanceSearchForm extends Component {
         this._onChangeInterpretationText = this._onChangeInterpretationText.bind(this);
         this._onChangeFavoritesName = this._onChangeFavoritesName.bind(this);
         this._onChangeCommentText = this._onChangeCommentText.bind(this);
-        this._onCheckStar = this._onCheckStar.bind(this);
-        this._onCheckSubscribe = this._onCheckSubscribe.bind(this);
+        this._onCheckFavorite = this._onCheckFavorite.bind(this);
+        this._onCheckSubscribed = this._onCheckSubscribed.bind(this);
         this._onCheckMention = this._onCheckMention.bind(this);
     }
 
@@ -44,8 +44,8 @@ export default class AdvanceSearchForm extends Component {
             commentText: '',
             showFavoritesNameSearch: false,
             //favoritesNameSearchHint: '',
-            star: false,
-            subscribe: false,
+            favorite: false,
+            subscribed: false,
             mention: false,
         };
     }
@@ -75,10 +75,8 @@ export default class AdvanceSearchForm extends Component {
         if (this.state.interpretationText) summaryStr += `interpretationText: ${this.state.interpretationText}, `;
         if (this.state.favoritesName) summaryStr += `favoritesName: ${this.state.favoritesName}, `;
         if (this.state.commentText) summaryStr += `commentText: ${this.state.commentText}, `;
-
-        // TODO: Need to use Star/Subscribe/Mention..  <-- DOES THIS WORK?  
-        if (this.state.star) summaryStr += `star: ${this.state.star}, `;
-        if (this.state.subscribe) summaryStr += `subscribe: ${this.state.subscribe}, `;
+        if (this.state.favorite) summaryStr += `favorite: ${this.state.favorite}, `;
+        if (this.state.subscribed) summaryStr += `subscribed: ${this.state.subscribed}, `;
         if (this.state.mention) summaryStr += `mention: ${this.state.mention}, `;
 
         if (summaryStr) summaryStr = `${otherUtils.advSearchStr}: ${summaryStr.substring(0, summaryStr.length - 2)}`;
@@ -138,14 +136,14 @@ export default class AdvanceSearchForm extends Component {
         this.setState({ commentText: event.target.value });
     }
 
-    _onCheckStar(event) {
+    _onCheckFavorite(event) {
         setTimeout(() => {
-            this.setState((oldState) => { return { star: !oldState.star }; });    
+            this.setState((oldState) => { return { favorite: !oldState.favorite }; });
         }, 1 );
     }
-    _onCheckSubscribe(event) {
+    _onCheckSubscribed(event) {
         setTimeout(() => {
-            this.setState((oldState) => { return { subscribe: !oldState.subscribe }; });    
+            this.setState((oldState) => { return { subscribed: !oldState.subscribed }; });
         }, 1 );
     }
     _onCheckMention(event) {
@@ -246,7 +244,31 @@ export default class AdvanceSearchForm extends Component {
                                 <tbody>
                                 <tr>
                                     <td>
-                                        <Checkbox label="Mention" value={this.state.mention} checked={this.state.mention} onCheck={this._onCheckMention} iconStyle={{left: "7"}} />
+                                        <Checkbox
+                                            label="Mention"
+                                            value={this.state.mention}
+                                            checked={this.state.mention}
+                                            onCheck={this._onCheckMention}
+                                            iconStyle={{left: 7}}
+                                        />
+                                    </td>
+                                    <td>
+                                        <Checkbox
+                                            label="Favorite"
+                                            value={this.state.favorite}
+                                            checked={this.state.favorite}
+                                            onCheck={this._onCheckFavorite}
+                                            iconStyle={{left: 7}}
+                                        />
+                                    </td>
+                                    <td>
+                                        <Checkbox
+                                            label="Subscribed"
+                                            value={this.state.subscribed}
+                                            checked={this.state.subscribed}
+                                            onCheck={this._onCheckSubscribed}
+                                            iconStyle={{left: 7}}
+                                        />
                                     </td>
                                 </tr>
                                 </tbody>

--- a/src/app/InterpretationList.component.js
+++ b/src/app/InterpretationList.component.js
@@ -123,7 +123,7 @@ const InterpretationList = React.createClass({
         return dataList;
     },
 
-    getSearchTerms(searchTerm) {
+    async getSearchTerms(searchTerm) {
         let searchTermUrl = '';
 
         if (searchTerm !== undefined) {
@@ -155,15 +155,22 @@ const InterpretationList = React.createClass({
                 
                 if (searchTerm.moreTerms.mention) searchTermUrl += `&filter=comments.mentions.username:eq:${this.props.d2.currentUser.username}`;
 
-                // TODO:
-                //      For 'Star' (Favorite), we can check it by '/{charId}/favorites...  so, we can do favorites:in:$---, but that would be in char..
-                //      So, we need to do 'chart.favorites:in:-userId--' ?  How can we tell which type?
-                //      Look at this in API after being able to submit for favorites/subscribers..
+                if (searchTerm.moreTerms.favorite)
+                    searchTermUrl += await this.getFilterForParentCondition("favorite:eq:true");
 
+                if (searchTerm.moreTerms.subscribed)
+                    searchTermUrl += await this.getFilterForParentCondition("subscribed:eq:true");
             }
         }
 
         return searchTermUrl;
+    },
+
+    getFilterForParentCondition(filter) {
+        return actions.getInterpretationsByParentFilter("id", filter)
+            .toPromise()
+            .then(interpretations => interpretations.map(interpretation => interpretation.id))
+            .then(interpretationIds => `&filter=id:in:[${interpretationIds.join(',')}]`)
     },
 
     getFavoriteSearchKeyName(favoriteType) {
@@ -357,8 +364,8 @@ const InterpretationList = React.createClass({
         });
     },
 
-    loadMore(page, afterFunc) {
-        const searchQuery = this.getSearchTerms(this.state.searchTerm);
+    async loadMore(page, afterFunc) {
+        const searchQuery = await this.getSearchTerms(this.state.searchTerm);
 
         actions.listInterpretation('', searchQuery, page).subscribe(result => {
             if (page === 1) {

--- a/src/app/actions/Interpretation.action.js
+++ b/src/app/actions/Interpretation.action.js
@@ -2,8 +2,24 @@
 import Action from 'd2-ui/lib/action/Action';
 import { getInstance as getD2 } from 'd2/lib/d2';
 
-const actions = Action.createActionsFromNames(['listInterpretation', 'getMap', 'getEventReport', 'updateLike', 'removeLike', 'deleteInterpretation', 'editInterpretation'], 'interpretation');
+const actions = Action.createActionsFromNames([
+    'listInterpretation',
+    'getInterpretationsByParentFilter',
+    'getMap',
+    'getEventReport',
+    'updateLike',
+    'removeLike',
+    'deleteInterpretation',
+    'editInterpretation'
+], 'interpretation');
 
+const parentTypes = [
+    "eventReport",
+    "eventChart",
+    "chart",
+    "map",
+    "reportTable",
+];
 
 // TODO: Does not have fail response, or always response!!!
 actions.listInterpretation
@@ -30,6 +46,18 @@ actions.listInterpretation
             complete(result);
         })
         .catch(error);
+    });
+});
+
+actions.getInterpretationsByParentFilter
+.subscribe(({ data: [fields, filter], complete }) => {
+    getD2().then(d2 => {
+        const filters = parentTypes.map(parentType => `${parentType}.${filter}`);
+        const filterParams = filters.map(filter => `filter=${filter}`).join("&");
+        const url = `/interpretations?paging=false&fields=${fields}&${filterParams}&rootJunction=OR`;
+        const api = d2.Api.getApi();
+
+        api.get(url).then(response => complete(response.interpretations));
     });
 });
 


### PR DESCRIPTION
Closes #https://github.com/EyeSeeTea/dhis2-core/issues/48

How it's implemented:

- As we expected, it has been not possible to simply add a filter to the existing unique query because favorite/subscribed fields in an interpretation depend on parent type ([example](https://play.dhis2.org/dev/api/interpretations/BR11Oy1Q4yR.json?fields=id,name,type,chart[id,favorite])).

- Solution used: Perform a previous API call like this (ex for favorite): `filter=chart.favorite:eq:true,reportTable.favorite:eq:true,...` with `rootJunction=OR`, get the interpretation ids from the response, and use them to build the final search query (`id:in:[ID1,ID2,...]`).

![screenshot from 2018-08-17 12-10-53](https://user-images.githubusercontent.com/24643/44261061-be456800-a216-11e8-8e3a-ff278676b2d7.png)
