### PR TITLE
Feature/merge user text filters 47

### DIFF
--- a/src/app/AdvanceSearchForm.component.js
+++ b/src/app/AdvanceSearchForm.component.js
@@ -17,12 +17,8 @@ export default class AdvanceSearchForm extends Component {
         this._setDateCreatedTo = this._setDateCreatedTo.bind(this);
         this._setDateModiFrom = this._setDateModiFrom.bind(this);
         this._setDateModiTo = this._setDateModiTo.bind(this);
-        this._authorSelected = this._authorSelected.bind(this);
-        this._commentatorSelected = this._commentatorSelected.bind(this);
-        this._onSelectAuthor = this._onSelectAuthor.bind(this);
-        this._onChangeInterpretationText = this._onChangeInterpretationText.bind(this);
+        this._onChangeText = this._onChangeText.bind(this);
         this._onChangeFavoritesName = this._onChangeFavoritesName.bind(this);
-        this._onChangeCommentText = this._onChangeCommentText.bind(this);
         this._onCheckFavorite = this._onCheckFavorite.bind(this);
         this._onCheckSubscribed = this._onCheckSubscribed.bind(this);
         this._onCheckMention = this._onCheckMention.bind(this);
@@ -35,13 +31,10 @@ export default class AdvanceSearchForm extends Component {
             dateCreatedTo: null,
             dateModiFrom: null,
             dateModiTo: null,
-            author: { id: '', displayName: '' },
-            authorDataSource: [],
-            commentator: { id: '', displayName: '' },
-            commentatorDataSource: [],
-            interpretationText: '',
+            user: { id: '', displayName: '' },
+            userDataSource: [],
+            text: '',
             favoritesName: '',
-            commentText: '',
             showFavoritesNameSearch: false,
             //favoritesNameSearchHint: '',
             favorite: false,
@@ -57,8 +50,7 @@ export default class AdvanceSearchForm extends Component {
     resetForm() {
         this.setState(this.getInitialData());
 
-        if (this.refs.author !== undefined) this.refs.author.clear();
-        if (this.refs.commentator !== undefined) this.refs.commentator.clear();
+        if (this.refs.user !== undefined) this.refs.user.clear();
     }
 
     generateAdvSearchText() {
@@ -70,11 +62,9 @@ export default class AdvanceSearchForm extends Component {
         if (this.state.dateCreatedTo) summaryStr += `dateCreatedTo: ${dateUtil.formatDateMMDDYYYY(this.state.dateCreatedTo, '/')}, `;
         if (this.state.dateModiFrom) summaryStr += `dateModiFrom: ${dateUtil.formatDateMMDDYYYY(this.state.dateModiFrom, '/')}, `;
         if (this.state.dateModiTo) summaryStr += `dateModiTo: ${dateUtil.formatDateMMDDYYYY(this.state.dateModiTo, '/')}, `;
-        if (this.state.author.id) summaryStr += `author: ${this.state.author.displayName}, `;
-        if (this.state.commentator.id) summaryStr += `commentator: ${this.state.commentator.displayName}, `;
-        if (this.state.interpretationText) summaryStr += `interpretationText: ${this.state.interpretationText}, `;
+        if (this.state.user.id) summaryStr += `user: ${this.state.user.displayName}, `;
+        if (this.state.text) summaryStr += `text: ${this.state.text}, `;
         if (this.state.favoritesName) summaryStr += `favoritesName: ${this.state.favoritesName}, `;
-        if (this.state.commentText) summaryStr += `commentText: ${this.state.commentText}, `;
         if (this.state.favorite) summaryStr += `favorite: ${this.state.favorite}, `;
         if (this.state.subscribed) summaryStr += `subscribed: ${this.state.subscribed}, `;
         if (this.state.mention) summaryStr += `mention: ${this.state.mention}, `;
@@ -113,29 +103,12 @@ export default class AdvanceSearchForm extends Component {
         this.setState({ dateModiTo });
     }
 
-    _authorSelected(user) {
-        this.state.author = user;
-    }
-
-    _commentatorSelected(user) {
-        this.state.commentator = user;
-    }
-
-    _onSelectAuthor(value, i) {
-        // Set real author here with setstate!!
-        this.state.author = this.state.authorDataSource[i].source;
-    }
-
-    _onChangeInterpretationText(event) {
-        this.setState({ interpretationText: event.target.value });
+    _onChangeText(event) {
+        this.setState({ text: event.target.value });
     }
     _onChangeFavoritesName(event) {
         this.setState({ favoritesName: event.target.value });
     }
-    _onChangeCommentText(event) {
-        this.setState({ commentText: event.target.value });
-    }
-
     _onCheckFavorite(event) {
         setTimeout(() => {
             this.setState((oldState) => { return { favorite: !oldState.favorite }; });
@@ -274,41 +247,24 @@ export default class AdvanceSearchForm extends Component {
                                 </tbody>
                                 </table>
                             </td>
-                        </tr>                        
-                        <tr>
-                            <td className="tdTitle"><span className="searchStyle">Author (user)</span></td>
-                            <td className="tdData">
-                                <AutoCompleteUsers searchId="author" fullWidth hintStyle={hintStyle} item={this.state.author} ref="author" />
-                            </td>
                         </tr>
+
                         <tr>
-                            <td className="tdTitle"><span className="searchStyle">Commentator (user)</span></td>
+                            <td className="tdTitle"><span className="searchStyle">User (interpretation/comment)</span></td>
                             <td className="tdData">
-                                <AutoCompleteUsers searchId="commentator" fullWidth hintStyle={hintStyle} item={this.state.commentator} ref="commentator" />
+                                <AutoCompleteUsers searchId="user" fullWidth hintStyle={hintStyle} item={this.state.user} ref="user" />
                             </td>
                         </tr>
 
                         <tr>
-                            <td className="tdTitle"><span className="searchStyle">Interpretation Text</span></td>
+                            <td className="tdTitle"><span className="searchStyle">Text (interpretation/comment)</span></td>
                             <td className="tdData">
                                 <TextField
                                     hintText="Partial Interpretation Text"
                                     hintStyle={hintStyle}
-                                    value={this.state.interpretationText}
+                                    value={this.state.text}
                                     fullWidth
-                                    onChange={this._onChangeInterpretationText}
-                                />
-                            </td>
-                        </tr>
-                        <tr>
-                            <td className="tdTitle"><span className="searchStyle">Comment Text</span></td>
-                            <td className="tdData">
-                                <TextField
-                                    hintText="Partial Comment Text"
-                                    hintStyle={hintStyle}
-                                    value={this.state.commentText}
-                                    fullWidth
-                                    onChange={this._onChangeCommentText}
+                                    onChange={this._onChangeText}
                                 />
                             </td>
                         </tr>

--- a/src/app/AutoCompleteUsers.component.js
+++ b/src/app/AutoCompleteUsers.component.js
@@ -36,7 +36,8 @@ const AutoCompleteUsers = React.createClass({
                 this.props.item.displayName = '';
             } else {
                 getD2().then(d2 => {
-                    const url = `users.json?paging=false&fields=id,displayName,userCredentials[username]&filter=name:ilike:${value}`;
+                    const url = `users.json?paging=false&fields=id,displayName,userCredentials[username]` +
+                        `&filter=name:ilike:${value}&filter=userCredentials.username:ilike:${value}&rootJunction=OR`;
 
                     d2.Api.getApi().get(url).then(result => {
                         const userList = [];

--- a/src/app/InterpretationList.component.js
+++ b/src/app/InterpretationList.component.js
@@ -132,9 +132,21 @@ const InterpretationList = React.createClass({
                 // id changed to array
                 searchTermUrl += `&filter=id:in:[${searchTerm.idList.toString()}]&order=created:desc`;
             } else if (searchTerm.moreTerms !== undefined) {
-                if (searchTerm.moreTerms.author && searchTerm.moreTerms.author.id !== '') searchTermUrl += `&filter=user.id:eq:${searchTerm.moreTerms.author.id}`;
+                if (searchTerm.moreTerms.user && searchTerm.moreTerms.user.id) {
+                    const userId = searchTerm.moreTerms.user.id;
+                    searchTermUrl += await this.getFilterByConditions([
+                        `user.id:eq:${userId}`,
+                        `comments.user.id:eq:${userId}`,
+                    ]);
+                }
 
-                if (searchTerm.moreTerms.commentator && searchTerm.moreTerms.commentator.id !== '') searchTermUrl += `&filter=comments.user.id:eq:${searchTerm.moreTerms.commentator.id}`;
+                if (searchTerm.moreTerms.text) {
+                    const text = searchTerm.moreTerms.text;
+                    searchTermUrl += await this.getFilterByConditions([
+                        `text:ilike:${text}`,
+                        `comments.text:ilike:${text}`,
+                    ]);
+                }
 
                 if (searchTerm.moreTerms.type) searchTermUrl += `&filter=type:eq:${searchTerm.moreTerms.type}`;
 
@@ -146,31 +158,39 @@ const InterpretationList = React.createClass({
 
                 if (searchTerm.moreTerms.dateModiTo) searchTermUrl += `&filter=lastUpdated:le:${dateUtil.formatDateYYYYMMDD(searchTerm.moreTerms.dateModiTo, '-')}`;
 
-                if (searchTerm.moreTerms.interpretationText) searchTermUrl += `&filter=text:ilike:${searchTerm.moreTerms.interpretationText}`;
-
                 // depending on the type, do other search..
                 if (searchTerm.moreTerms.favoritesName && searchTerm.moreTerms.type) searchTermUrl += `&filter=${this.getFavoriteSearchKeyName(searchTerm.moreTerms.type)}:ilike:${searchTerm.moreTerms.favoritesName}`;
 
-                if (searchTerm.moreTerms.commentText) searchTermUrl += `&filter=comments.text:ilike:${searchTerm.moreTerms.commentText}`;
-                
                 if (searchTerm.moreTerms.mention) searchTermUrl += `&filter=comments.mentions.username:eq:${this.props.d2.currentUser.username}`;
 
                 if (searchTerm.moreTerms.favorite)
-                    searchTermUrl += await this.getFilterForParentCondition("favorite:eq:true");
+                    searchTermUrl += await this.getFilterByParentCondition("favorite:eq:true");
 
                 if (searchTerm.moreTerms.subscribed)
-                    searchTermUrl += await this.getFilterForParentCondition("subscribed:eq:true");
+                    searchTermUrl += await this.getFilterByParentCondition("subscribed:eq:true");
             }
         }
 
         return searchTermUrl;
     },
 
-    getFilterForParentCondition(filter) {
-        return actions.getInterpretationsByParentFilter("id", filter)
+    toFilter(interpretationsObservable) {
+        // Limit Uids to avoid 413 Request too large
+        // maxUids = (maxUrlSize - urlAndOtherParamsSize) / (uidSize + encodedCommaSize)
+        const maxUids = (8192 - 1000) / (11 + 3);
+
+        return interpretationsObservable
             .toPromise()
             .then(interpretations => interpretations.map(interpretation => interpretation.id))
-            .then(interpretationIds => `&filter=id:in:[${interpretationIds.join(',')}]`)
+            .then(interpretationIds => `&filter=id:in:[${interpretationIds.slice(0, maxUids).join(',')}]`);
+    },
+
+    getFilterByConditions(conditions) {
+        return this.toFilter(actions.getAllInterpretationsByOrFilters("id", conditions));
+    },
+
+    getFilterByParentCondition(condition) {
+        return this.toFilter(actions.getInterpretationsByParentFilter("id", condition));
     },
 
     getFavoriteSearchKeyName(favoriteType) {
@@ -430,7 +450,7 @@ const InterpretationList = React.createClass({
             { type: 'reportEvent', performed: false, query: `interpretations?paging=false&fields=id&filter=eventReport.name:ilike:${keyword}` },
             { type: 'map', performed: false, query: `interpretations?paging=false&fields=id&filter=map.name:ilike:${keyword}` },
             { type: 'author', performed: false, query: `interpretations?paging=false&fields=id&filter=user.name:ilike:${keyword}` },
-            { type: 'commentator', performed: false, query: `interpretations?paging=false&fields=id&filter=comments.user.name:ilike:${keyword}` },
+            { type: 'commentator', performed: false, query: `interpretations?paging=false&fields=id&filter=comments.user.name:ilike:${keyword}` },            
             { type: 'interpretationText', performed: false, query: `interpretations?paging=false&fields=id&filter=text:ilike:${keyword}` },
             { type: 'commentText', performed: false, query: `interpretations?paging=false&fields=id&filter=comments.text:ilike:${keyword}` },
         ];


### PR DESCRIPTION
Closes EyeSeeTea/dhis2-core/issues/47

Implementation notes:

- Up to this moment, all filters in advanced search form were AND filters. Now those merged are OR filters `condition1 AND condition2 AND (userAuthor OR userCommentator) AND (interpretationText OR commentText)`. DHIS2 does not support having AND and OR filters, so we have to break it down into different requests. When fields are filled, separate requests for user and text are performed (using `rootJunction=OR`, **available from 2.25**), the IDs are collected and then inserted in the final AND request: `id:in:[ID1,ID2,...]`. 
- GUI: I've added the text `xyz (interpretation/comment)` to both fields to make clear where it's searching. _TO BE VALIDATED_.
- I noticed that the user autocomplete filtered only by displayName. Now it also filters by username.

![screenshot from 2018-08-20 10-43-31](https://user-images.githubusercontent.com/24643/44330016-41103200-a466-11e8-8f64-44d96a6d87e5.png)