### PR TITLE
Fix date filters and add clear button

### DIFF
--- a/src/app/AdvanceSearchForm.component.js
+++ b/src/app/AdvanceSearchForm.component.js
@@ -1,6 +1,8 @@
 
 import React, { Component } from 'react';
-import { DatePicker, TextField, SelectField, MenuItem, Checkbox } from 'material-ui';
+import { DatePicker, TextField, SelectField, MenuItem, Checkbox, IconButton } from 'material-ui';
+import SvgIcon from 'd2-ui/lib/svg-icon/SvgIcon';
+
 import AutoCompleteUsers from './AutoCompleteUsers.component';
 import { otherUtils, dateUtil } from './utils';
 
@@ -13,10 +15,6 @@ export default class AdvanceSearchForm extends Component {
 
         this._clickCloseBtn = this._clickCloseBtn.bind(this);
         this._typeChanged = this._typeChanged.bind(this);
-        this._setDateCreatedFrom = this._setDateCreatedFrom.bind(this);
-        this._setDateCreatedTo = this._setDateCreatedTo.bind(this);
-        this._setDateModiFrom = this._setDateModiFrom.bind(this);
-        this._setDateModiTo = this._setDateModiTo.bind(this);
         this._onChangeText = this._onChangeText.bind(this);
         this._onChangeFavoritesName = this._onChangeFavoritesName.bind(this);
         this._onCheckFavorite = this._onCheckFavorite.bind(this);
@@ -87,22 +85,6 @@ export default class AdvanceSearchForm extends Component {
         this.setState({ showFavoritesNameSearch: showFavoritesNameSearchRow });
     }
 
-    _setDateCreatedFrom(event, date) {
-        this.setState({ dateCreatedFrom: date });
-    }
-
-    _setDateCreatedTo(event, date) {
-        this.setState({ dateCreatedTo: date });
-    }
-
-    _setDateModiFrom(event, dateModiFrom) {
-        this.setState({ dateModiFrom });
-    }
-
-    _setDateModiTo(event, dateModiTo) {
-        this.setState({ dateModiTo });
-    }
-
     _onChangeText(event) {
         this.setState({ text: event.target.value });
     }
@@ -129,11 +111,42 @@ export default class AdvanceSearchForm extends Component {
         setTimeout( returnFunc, 1 );
     }
 
+    renderDateFilterPicker = props => {
+        const { field, hintText } = props;
+        const value = this.state[field];
+        const onChange = (ev, value) => this.setState({ [field]: value });
+        const onClearClick = (ev, value) => this.setState({ [field]: undefined });
+        const isClearButtonVisible = !!this.state[field];
+
+        return (
+            <div style={{ display: "flex" }}>
+                <DatePicker
+                    value={value}
+                    style={{ width: '130px' }}
+                    underlineStyle={{ width: '130px' }}
+                    hintText={hintText}
+                    hintStyle={{ fontSize: '14px' }}
+                    onChange={onChange}
+                />
+
+                {isClearButtonVisible &&
+                    <IconButton
+                        style={{ position: "relative", right: 30, padding: 0, width: 0 }}
+                        onClick={onClearClick}
+                    >
+                        <SvgIcon icon="Clear" />
+                    </IconButton>
+                }
+            </div>
+        );
+    }
+
     render() {
         const hintStyle = { fontSize: '14px' };
         const underlineStyle = { width: '400px' };
         const menuStyle = { fontSize: '14px' };
         const fontStyle = { fontSize: '14px' };
+        const DateFilterPicker = this.renderDateFilterPicker;
 
         return (
             <div className="advanceSearchForm">
@@ -177,13 +190,13 @@ export default class AdvanceSearchForm extends Component {
                                 <tbody>
                                 <tr>
                                 <td>
-                                    <DatePicker value={this.state.dateCreatedFrom} style={{ width: '130px' }} underlineStyle={{ width: '130px' }} hintText="From" hintStyle={hintStyle} onChange={this._setDateCreatedFrom} />
+                                    <DateFilterPicker field="dateCreatedFrom" hintText="From" />
                                 </td>
                                 <td>
                                     <div>-</div>
                                 </td>
                                 <td>
-                                    <DatePicker value={this.state.dateCreatedTo} style={{ width: '130px' }} underlineStyle={{ width: '130px' }} hintText="To" hintStyle={hintStyle} onChange={this._setDateCreatedTo} />
+                                    <DateFilterPicker field="dateCreatedTo" hintText="To" />
                                 </td>
                                 </tr>
                                 </tbody>
@@ -197,13 +210,13 @@ export default class AdvanceSearchForm extends Component {
                                 <tbody>
                                 <tr>
                                     <td>
-                                        <DatePicker value={this.state.dateModiFrom} style={{ width: '130px' }} underlineStyle={{ width: '130px' }} hintText="From" hintStyle={hintStyle} onChange={this._setDateModiFrom} />
+                                        <DateFilterPicker field="dateModiFrom" hintText="From" />
                                     </td>
                                     <td>
                                         <div>-</div>
                                     </td>
                                     <td>
-                                        <DatePicker value={this.state.dateModiTo} style={{ width: '130px' }} underlineStyle={{ width: '130px' }} hintText="To" hintStyle={hintStyle} onChange={this._setDateModiTo} />
+                                        <DateFilterPicker field="dateModiTo" hintText="To" />
                                     </td>
                                 </tr>
                                 </tbody>

--- a/src/app/InterpretationList.component.js
+++ b/src/app/InterpretationList.component.js
@@ -158,11 +158,11 @@ const InterpretationList = React.createClass({
 
                 if (searchTerm.moreTerms.dateCreatedFrom) searchTermUrl += `&filter=created:ge:${dateUtil.formatDateYYYYMMDD(searchTerm.moreTerms.dateCreatedFrom, '-')}`;
 
-                if (searchTerm.moreTerms.dateCreatedTo) searchTermUrl += `&filter=created:le:${dateUtil.formatDateYYYYMMDD(searchTerm.moreTerms.dateCreatedTo, '-')}`;
+                if (searchTerm.moreTerms.dateCreatedTo) searchTermUrl += `&filter=created:lt:${dateUtil.formatDateYYYYMMDD(dateUtil.addDays(searchTerm.moreTerms.dateCreatedTo, 1), '-')}`;
 
                 if (searchTerm.moreTerms.dateModiFrom) searchTermUrl += `&filter=lastUpdated:ge:${dateUtil.formatDateYYYYMMDD(searchTerm.moreTerms.dateModiFrom, '-')}`;
 
-                if (searchTerm.moreTerms.dateModiTo) searchTermUrl += `&filter=lastUpdated:le:${dateUtil.formatDateYYYYMMDD(searchTerm.moreTerms.dateModiTo, '-')}`;
+                if (searchTerm.moreTerms.dateModiTo) searchTermUrl += `&filter=lastUpdated:lt:${dateUtil.formatDateYYYYMMDD(dateUtil.addDays(searchTerm.moreTerms.dateModiTo, 1), '-')}`;
 
                 // depending on the type, do other search..
                 if (searchTerm.moreTerms.favoritesName && searchTerm.moreTerms.type) searchTermUrl += `&filter=${this.getFavoriteSearchKeyName(searchTerm.moreTerms.type)}:ilike:${searchTerm.moreTerms.favoritesName}`;

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -32,6 +32,11 @@ export const dateUtil = {
 
         return `${monthStr}${separator}${dateStr}${separator}${date.getFullYear()}`;
     },
+    addDays(date, nDays) {
+        let newDate = new Date(date);
+        newDate.setDate(date.getDate() + nDays);
+        return newDate;
+    },
 };
 
 export const restUtil = {


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes EyeSeeTea/interpretation-app/issues/18

### :memo: Implementation

- Fix end date: Currently, the filter was "filter=created:le:2018-01-25". The API, apparently, converts this date-only value to a datetime (2018-01-25-00:00:00) and then compares with the record value. Thus, the last day is effectively not included. Solution: Add one day to the filter date and use operator less-than: "filter=created:lt:2018-01-26"

- Added a clear icon to the right of the text field. I've taken the opportunity to refactor and abstract it as a component.

### :art: Screenshots

![screenshot from 2018-09-19 13-35-14](https://user-images.githubusercontent.com/24643/45750984-2f5ead80-bc11-11e8-9a53-266e29f5b81f.png)