### PR TITLE
Swap search buttons and keep only <search> button as primary

### DIFF
--- a/src/app/SearchBox.component.js
+++ b/src/app/SearchBox.component.js
@@ -62,8 +62,10 @@ export default class SearchBox extends Component {
 
     _advSearchFormReset() {
         const { advancedSearchForm } = this.refs;
-        if (advancedSearchForm)
+        if (advancedSearchForm) {
             advancedSearchForm.resetForm();
+            setTimeout(() => this._performAdvancedSearch(), 1);
+        }
     }
 
     _performAdvancedSearch() {

--- a/src/app/SearchBox.component.js
+++ b/src/app/SearchBox.component.js
@@ -99,14 +99,13 @@ export default class SearchBox extends Component {
     render() {
         const actions = [
             <FlatButton
+                label="Reset"
+                onClick={this._advSearchFormReset}
+            />,
+            <FlatButton
                 label="Search"
                 primary
                 onClick={this._performAdvancedSearch}
-            />,
-            <FlatButton
-                label="Reset"
-                primary
-                onClick={this._advSearchFormReset}
             />,
         ];
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://github.com/EyeSeeTea/interpretation-app/issues/20

### :memo: Implementation

- Both buttons were primary, I've kept only the search button as primary. By default, material UI just highlights a primary button with a blue font text. I think it looks pretty good, we can add background color if we see it fit. 

### :art: Screenshots

![screenshot from 2018-09-19 13-52-36](https://user-images.githubusercontent.com/24643/45751891-0db2f580-bc14-11e8-83f2-ba67b4976374.png)