### PR TITLE
Use interpretation.access to show/hide interpretation actions

### DIFF
--- a/src/app/Interpretation.component.js
+++ b/src/app/Interpretation.component.js
@@ -459,6 +459,8 @@ const Interpretation = React.createClass({
             />,
         ];
 
+        const showAdminActions = this.props.data.access && this.props.data.access.update;
+
         return (
 			<div id={interpretationTagId} key={interpretationTagId} className="interpretations">
 				<div className="interpretationContainer" >
@@ -505,7 +507,7 @@ const Interpretation = React.createClass({
                         {otherUtils.findItemFromList(this.props.data.likedBy, 'id', this.props.currentUser.id) === undefined ? <a onClick={this._likeHandler} id={likeLinkTagId}>Like</a> : <a onClick={this._unlikeHandler} id={likeLinkTagId}>Unlike</a> } 
                         <label className="linkArea">·</label>
                         <a onClick={this._replyInterpretation}>Reply</a>
-                        <span className={this.props.currentUser.id === this.props.data.userId || this.props.currentUser.superUser ? '' : 'hidden'} >
+                        <span className={showAdminActions ? '' : 'hidden'} >
                         <label className="linkArea">·</label><a onClick={this._showEditHandler}>Edit</a>
                         <label className="linkArea">·</label><a onClick={this._openSharingDialog}>Share</a>
                         <label className="linkArea">·</label><a onClick={this._deleteHandler}>Delete</a>

--- a/src/app/actions/Interpretation.action.js
+++ b/src/app/actions/Interpretation.action.js
@@ -26,7 +26,7 @@ const parentTypes = [
 actions.listInterpretation
 .subscribe(({ data: [model, searchData, page], complete, error }) => {
     getD2().then(d2 => {
-    let url = 'interpretations?fields=id,type,text,created,lastUpdated,userGroupAccesses[*]'
+    let url = 'interpretations?fields=id,type,text,created,lastUpdated,userGroupAccesses[*],access'
         + ',externalAccess,publicAccess,likes,likedBy[id,name],user[id,name,userCredentials[username]]'
         + ',comments[id,created,latestUpdate,text,user[id,name,userCredentials[username]]]'
         + ',eventReport[id,name,relativePeriods,userAccesses[*],userGroupAccesses[*],externalAccess,publicAccess,user[id,name],favorites,subscribers,mentions]'


### PR DESCRIPTION
Fix: "Share action is not showing for a user with interpretation R/W"